### PR TITLE
fix go type conflict

### DIFF
--- a/gowsdl.go
+++ b/gowsdl.go
@@ -536,7 +536,12 @@ func makePublic(identifier string) string {
 		return identifier
 	}
 
-	field[0] = unicode.ToUpper(field[0])
+	uc := unicode.ToUpper(field[0])
+	if field[0] != uc {
+		field[0] = uc
+		field = append(field, '_')
+	}
+
 	return string(field)
 }
 

--- a/gowsdl_test.go
+++ b/gowsdl_test.go
@@ -77,13 +77,13 @@ func TestAttributeRef(t *testing.T) {
 	}
 
 	expected := `type ResponseStatus struct {
-	Status	[]struct {
+	Status_	[]struct {
 		Value	string
 
-		Code	string	` + "`" + `xml:"code,attr,omitempty"` + "`" + `
+		Code_	string	` + "`" + `xml:"code,attr,omitempty"` + "`" + `
 	}	` + "`" + `xml:"status,omitempty"` + "`" + `
 
-	ResponseCode	string	` + "`" + `xml:"responseCode,attr,omitempty"` + "`" + `
+	ResponseCode_	string	` + "`" + `xml:"responseCode,attr,omitempty"` + "`" + `
 }`
 	if actual != expected {
 		t.Error("got " + actual + " want " + expected)
@@ -144,7 +144,7 @@ func TestEnumerationsGeneratedCorrectly(t *testing.T) {
 		}
 	}
 	enumStringTest(t, "chromedata.wsdl", "DriveTrainFrontWheelDrive", "DriveTrain", "Front Wheel Drive")
-	enumStringTest(t, "vboxweb.wsdl", "SettingsVersionV1_14", "SettingsVersion", "v1_14")
+	enumStringTest(t, "vboxweb.wsdl", "SettingsVersionV1_14_", "SettingsVersion", "v1_14")
 
 }
 


### PR DESCRIPTION
Fixed Go type name conflict caused by mixed capital and uncapital names.
Ref: https://github.com/hooklift/gowsdl/issues/101